### PR TITLE
Support Amazon Linux in erlang cookbook

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,7 +24,7 @@ when "debian", "ubuntu"
   erlpkg = node[:erlang][:gui_tools] ? "erlang" : "erlang-nox"
   package erlpkg
   package "erlang-dev"
-when "redhat", "centos", "scientific"
+when "redhat", "centos", "scientific", "amazon"
   include_recipe "yum::epel"
   yum_repository "erlang" do
     name "EPELErlangrepo"


### PR DESCRIPTION
This is a simple change to add support for Amazon Linux to the erlang cookbook. This is the pull request for [COOK-1215|http://tickets.opscode.com/browse/COOK-1215].
