### PR TITLE
[COOK-2915] Debian codename override

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,3 +23,4 @@ default['erlang']['source']['url'] = "http://erlang.org/download/otp_src_#{node[
 default['erlang']['source']['checksum'] = "f94f7de7328af3c0cdc42089c1a4ecd03bf98ec680f47eb5e6cddc50261cabde"
 
 default['erlang']['esl']['version'] = nil
+default['erlang']['esl']['lsb_codename'] = node['lsb']['codename']

--- a/recipes/esl.rb
+++ b/recipes/esl.rb
@@ -27,7 +27,7 @@ when 'debian'
 
   apt_repository 'erlang_solutions_repo' do
     uri 'http://binaries.erlang-solutions.com/debian'
-    distribution node['lsb']['codename']
+    distribution node['erlang']['esl']['lsb_codename']
     components ['contrib']
     key 'http://binaries.erlang-solutions.com/debian/erlang_solutions.asc'
     action :add


### PR DESCRIPTION
Sometimes we want to specify an older release. For instance if the package maintainer hasn't created an apt repository for a newer distribution release.

http://tickets.opscode.com/browse/COOK-2915
