### PR TITLE
[COOK-4610] New repository for ESL

### DIFF
--- a/recipes/esl.rb
+++ b/recipes/esl.rb
@@ -26,10 +26,10 @@ when 'debian'
   include_recipe 'apt'
 
   apt_repository 'erlang_solutions_repo' do
-    uri 'http://binaries.erlang-solutions.com/debian'
+    uri 'http://packages.erlang-solutions.com/debian/'
     distribution node['erlang']['esl']['lsb_codename']
     components ['contrib']
-    key 'http://binaries.erlang-solutions.com/debian/erlang_solutions.asc'
+    key 'http://packages.erlang-solutions.com/debian/erlang_solutions.asc'
     action :add
   end
 


### PR DESCRIPTION
binaries.erlang-solutions.com has permanently moved (301) to
packages.erlang-solutions.com.. Confirmed with wget. This is causing
chef-client to timeout.

Contributor License on file.
Here is wget output
wget http://binaries.erlang-solutions.com/debian
--2014-04-30 19:23:15--  http://binaries.erlang-solutions.com/debian
Resolving binaries.erlang-solutions.com (binaries.erlang-solutions.com)... 46.235.224.136
Connecting to binaries.erlang-solutions.com (binaries.erlang-solutions.com)|46.235.224.136|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: http://packages.erlang-solutions.com//debian [following]
--2014-04-30 19:24:30--  http://packages.erlang-solutions.com//debian
Resolving packages.erlang-solutions.com (packages.erlang-solutions.com)... 31.172.186.53
Connecting to packages.erlang-solutions.com (packages.erlang-solutions.com)|31.172.186.53|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: http://packages.erlang-solutions.com/debian/ [following]
--2014-04-30 19:24:30--  http://packages.erlang-solutions.com/debian/
Reusing existing connection to packages.erlang-solutions.com:80.
HTTP request sent, awaiting response... 200 OK
