### PR TITLE
Allow for systems with that do not have lsb installed

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,4 +25,4 @@ default['erlang']['source']['build_flags'] = ''
 default['erlang']['source']['cflags'] = ''
 
 default['erlang']['esl']['version'] = nil
-default['erlang']['esl']['lsb_codename'] = node['lsb']['codename'] ? node['lsb']['codename'] : 'no_lsb'
+default['erlang']['esl']['lsb_codename'] = node['lsb'] ? node['lsb']['codename'] : 'no_lsb'


### PR DESCRIPTION
This fix allows for a system that doesn't have LSB installed you get the following error undefined method `[]' for nil:NilClass. This is especially useful if this cookbook is a dependency for another cookbook that runs on windows.
