### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,16 +18,16 @@
 - `libraries/` - Library helpers to assist with the cookbook. May contain multiple files depending on complexity of the cookbook.
 - `templates/` - ERB templates that may be used in the cookbook
 - `files/` - files that may be used in the cookbook
-- `metadata.rb`, `Berksfile` - Cookbook metadata and dependencies
+- `metadata.rb`, `Policyfile.rb` - Cookbook metadata and dependency resolution
 
 ## Build and Test System
 
 ### Environment Setup
-**MANDATORY:** Install Chef Workstation first - provides chef, berks, cookstyle, kitchen tools.
+**MANDATORY:** Install Chef Workstation first - provides chef, cookstyle, kitchen tools.
 
 ### Essential Commands (strict order)
 ```bash
-berks install                   # Install dependencies (always first)
+chef install Policyfile.rb      # Install dependencies (always first)
 cookstyle                       # Ruby/Chef linting
 yamllint .                      # YAML linting
 markdownlint-cli2 '**/*.md'     # Markdown linting
@@ -42,7 +42,7 @@ chef exec rspec                 # Unit tests (ChefSpec)
 - **Full CI Runtime:** 30+ minutes for complete matrix
 
 ### Common Issues and Solutions
-- **Always run `berks install` first** - most failures are dependency-related
+- **Always run `chef install Policyfile.rb` first** - most failures are dependency-related
 - **Docker must be running** for kitchen tests
 - **Chef Workstation required** - no workarounds, no alternatives
 - **Test data bags needed** (optional for some cookbooks) in `test/integration/data_bags/` for convergence
@@ -88,7 +88,7 @@ These instructions are validated for Sous Chefs cookbooks. **Do not search for b
 
 **Error Resolution Checklist:**
 1. Verify Chef Workstation installation
-2. Confirm `berks install` completed successfully
+2. Confirm `chef install Policyfile.rb` completed successfully
 3. Ensure Docker is running for integration tests
 4. Check for missing test data dependencies
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.4
     permissions:
       actions: write
       checks: write
@@ -42,7 +42,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Cinc Workstation
-        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.2
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Dokken
         uses: actionshub/test-kitchen@3.0.0
         env:

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -11,4 +11,4 @@ name: conventional-commits
 
 jobs:
   conventional-commits:
-    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.4

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Cinc Workstation
-        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.2
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -11,6 +11,6 @@ name: prevent-file-change
 
 jobs:
   prevent-file-change:
-    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.4
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   release:
-    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.4
     secrets:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,29 +15,29 @@ Provides resources to install Erlang from distro packages, Erlang Solutions pack
 
 ### APT (Debian/Ubuntu)
 
-- Debian 12: `erlang-dev` is available from the Debian repositories and depends on the matching `erlang-base` package.
-- Debian 13: Erlang packages are available from the Debian repositories.
-- Ubuntu 22.04: Erlang packages are available from Ubuntu Universe for amd64 and common port architectures.
-- Ubuntu 24.04: Erlang packages are available from Ubuntu Universe for amd64 and common port architectures.
-- Ubuntu 26.04: Erlang packages are available from Ubuntu Universe for amd64 and common port architectures. The cookbook metadata supports it through `supports 'ubuntu', '>= 22.04'`, but it is not in the Dokken CI matrix until a `dokken/ubuntu-26.04` image is published.
-- Erlang Solutions discontinued prebuilt Erlang/OTP and Elixir binary packages effective 2025-01-20. The `erlang_esl` resource is retained only for legacy repositories and is not covered by Kitchen integration tests.
+* Debian 12: `erlang-dev` is available from the Debian repositories and depends on the matching `erlang-base` package.
+* Debian 13: Erlang packages are available from the Debian repositories.
+* Ubuntu 22.04: Erlang packages are available from Ubuntu Universe for amd64 and common port architectures.
+* Ubuntu 24.04: Erlang packages are available from Ubuntu Universe for amd64 and common port architectures.
+* Ubuntu 26.04: Erlang packages are available from Ubuntu Universe for amd64 and common port architectures. The cookbook metadata supports it through `supports 'ubuntu', '>= 22.04'`, but it is not in the Dokken CI matrix until a `dokken/ubuntu-26.04` image is published.
+* Erlang Solutions discontinued prebuilt Erlang/OTP and Elixir binary packages effective 2025-01-20. The `erlang_esl` resource is retained only for legacy repositories and is not covered by Kitchen integration tests.
 
 ### DNF/YUM (RHEL family)
 
-- RHEL-compatible 8 and 9 platforms can install Erlang from EPEL. EPEL currently publishes `erlang` for EL8 and EL9.
-- RHEL-compatible 10 platforms are supported by the OS vendors, and Dokken images exist for several EL10 derivatives, but EPEL does not currently publish an Erlang package for EL10. EL10 is not included in the package-install test matrix.
-- Oracle Linux is not included in metadata or Kitchen because EPEL repository handling differs from other EL derivatives and Erlang package availability was not confirmed in Oracle public EPEL indexes.
-- Fedora publishes Erlang packages in the Fedora repositories.
-- Erlang Solutions RPM packages use the Erlang Solutions CentOS-style repository URL supplied to `erlang_esl`. Treat this as legacy-only because Erlang Solutions stopped publishing new binary packages.
+* RHEL-compatible 8 and 9 platforms can install Erlang from EPEL. EPEL currently publishes `erlang` for EL8 and EL9.
+* RHEL-compatible 10 platforms are supported by the OS vendors, and Dokken images exist for several EL10 derivatives, but EPEL does not currently publish an Erlang package for EL10. EL10 is not included in the package-install test matrix.
+* Oracle Linux is not included in metadata or Kitchen because EPEL repository handling differs from other EL derivatives and Erlang package availability was not confirmed in Oracle public EPEL indexes.
+* Fedora publishes Erlang packages in the Fedora repositories.
+* Erlang Solutions RPM packages use the Erlang Solutions CentOS-style repository URL supplied to `erlang_esl`. Treat this as legacy-only because Erlang Solutions stopped publishing new binary packages.
 
 ### Zypper (SUSE)
 
-- openSUSE Leap is not included in the tested platform matrix. Erlang Solutions does not provide a zypper repository path used by this cookbook.
+* openSUSE Leap is not included in the tested platform matrix. Erlang Solutions does not provide a zypper repository path used by this cookbook.
 
 ## Architecture Limitations
 
-- Distribution packages generally support amd64 and the common distribution port architectures. Kitchen coverage for this cookbook is container-based amd64.
-- Erlang Solutions package availability varies by repository path and release; the cookbook exposes repository URL properties so users can override stale upstream paths.
+* Distribution packages generally support amd64 and the common distribution port architectures. Kitchen coverage for this cookbook is container-based amd64.
+* Erlang Solutions package availability varies by repository path and release; the cookbook exposes repository URL properties so users can override stale upstream paths.
 
 ## Source/Compiled Installation
 
@@ -53,7 +53,7 @@ Erlang/OTP upstream documents source builds as supported on Unix/Linux systems w
 
 ## Known Issues
 
-- Legacy CentOS Linux, Scientific Linux, Amazon Linux, Debian 11, and Ubuntu 20.04 are not included in the modernized platform test matrix.
-- EL10 and Ubuntu 26.04 are not included in Kitchen/CI yet because package and Dokken image availability are not both present.
-- Chef metadata `supports` declarations cannot express tested upper bounds; Kitchen and CI are the authoritative tested platform list.
-- `erlang_source` builds from upstream source tarballs and can take significantly longer than package installs.
+* Legacy CentOS Linux, Scientific Linux, Amazon Linux, Debian 11, and Ubuntu 20.04 are not included in the modernized platform test matrix.
+* EL10 and Ubuntu 26.04 are not included in Kitchen/CI yet because package and Dokken image availability are not both present.
+* Chef metadata `supports` declarations cannot express tested upper bounds; Kitchen and CI are the authoritative tested platform list.
+* `erlang_source` builds from upstream source tarballs and can take significantly longer than package installs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,15 @@
-# Limitations
+# AGENTS.md
+
+## Cookbook Purpose
+
+Provides resources to install Erlang from distro packages, Erlang Solutions packages, or source.
+
+## Agent Findings
+
+* This cookbook is in an incremental modernization pass. Preserve existing public recipes and attributes unless a later full migration is explicitly selected.
+* Dependency management should use `Policyfile.rb`; do not reintroduce Berkshelf.
+
+## Known Limitations
 
 ## Package Availability
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+name 'erlang'
+
+run_list 'test::default'
+
+cookbook 'erlang', path: '.'
+cookbook 'apt', git: 'https://github.com/sous-chefs/apt.git', branch: 'main'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -2,7 +2,7 @@
 
 name 'erlang'
 
-run_list 'test::default'
+run_list 'recipe[test::default]'
 
 cookbook 'erlang', path: '.'
 cookbook 'apt', git: 'https://github.com/sous-chefs/apt.git', branch: 'main'
@@ -11,5 +11,5 @@ cookbook 'test', path: './test/cookbooks/test'
 Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
   recipe_name = File.basename(recipe, '.rb')
 
-  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+  named_run_list recipe_name.to_sym, 'recipe[test::' + recipe_name + ']'
 end

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,7 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -49,9 +49,13 @@ x-verifiers:
 
 suites:
   - name: default
+    provisioner:
+      named_run_list: default
     run_list: *default_run_list
     verifier: *default_verifier
 
   - name: source
+    provisioner:
+      named_run_list: source
     run_list: *source_run_list
     verifier: *source_verifier

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update CI/Copilot workflow references to current sous-chefs workflow/action versions
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- /opt/chef-workstation/embedded/bin/rspec --format progress
- kitchen list